### PR TITLE
Fix pathlib link on documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ syntax at the same time.
 
 By making the code exclusively Python 3.5+, I'm able to focus on the
 quality of the checks and re-use all the nice features of the new
-releases (check out [pathlib](docs.python.org/3/library/pathlib.html))
+releases (check out [pathlib](https://docs.python.org/3/library/pathlib.html))
 instead of wasting cycles on Unicode compatibility, etc.
 
 


### PR DESCRIPTION
Without the scheme part it references the project itself, not external links.