### PR TITLE
 Make temp file creation Windows compatible

### DIFF
--- a/flake8_mypy.py
+++ b/flake8_mypy.py
@@ -279,7 +279,7 @@ class MypyChecker:
             except ValueError:
                 pass   # not relative to the cwd
 
-        re_filename = str(filename).replace('.', r'\.')
+        re_filename = re.escape(str(filename))
         if re_filename.startswith(r'\./'):
             re_filename = re_filename[3:]
         return re.compile(

--- a/flake8_mypy.py
+++ b/flake8_mypy.py
@@ -184,14 +184,22 @@ class MypyChecker:
         # unexpected clashes with other .py and .pyi files in the same original
         # directory.
         with TemporaryDirectory(prefix='flake8mypy_') as d:
-            with NamedTemporaryFile(
-                'w', encoding='utf8', prefix='tmpmypy_', suffix='.py', dir=d
-            ) as f:
-                self.filename = f.name
+            file = NamedTemporaryFile(
+                'w',
+                encoding='utf8',
+                prefix='tmpmypy_',
+                suffix='.py',
+                dir=d,
+                delete=False,
+            )
+            try:
+                self.filename = file.name
                 for line in self.lines:
-                    f.write(line)
-                f.flush()
+                    file.write(line)
+                file.close()
                 yield from self._run()
+            finally:
+                os.remove(file.name)
 
     def _run(self) -> Iterator[_Flake8Error]:
         mypy_cmdline = self.build_mypy_cmdline(self.filename, self.options.mypy_config)


### PR DESCRIPTION
On Windows the temp file must be closed, otherwise mypy can't open it again.
Unfortunately, we then loose the nice to read `with` sugar and obviously
must call `os.remove` manually.

This is on top of #17 bc I had no way to test this otherwise.

