### PR TITLE
Fix col offset

### DIFF
--- a/flake8_mypy.py
+++ b/flake8_mypy.py
@@ -279,7 +279,7 @@ class MypyChecker:
             except ValueError:
                 pass   # not relative to the cwd
 
-        re_filename = str(filename).replace('.', r'\.')
+        re_filename = re.escape(str(filename))
         if re_filename.startswith(r'\./'):
             re_filename = re_filename[3:]
         return re.compile(

--- a/flake8_mypy.py
+++ b/flake8_mypy.py
@@ -184,14 +184,22 @@ class MypyChecker:
         # unexpected clashes with other .py and .pyi files in the same original
         # directory.
         with TemporaryDirectory(prefix='flake8mypy_') as d:
-            with NamedTemporaryFile(
-                'w', encoding='utf8', prefix='tmpmypy_', suffix='.py', dir=d
-            ) as f:
-                self.filename = f.name
+            file = NamedTemporaryFile(
+                'w',
+                encoding='utf8',
+                prefix='tmpmypy_',
+                suffix='.py',
+                dir=d,
+                delete=False,
+            )
+            try:
+                self.filename = file.name
                 for line in self.lines:
-                    f.write(line)
-                f.flush()
+                    file.write(line)
+                file.close()
                 yield from self._run()
+            finally:
+                os.remove(file.name)
 
     def _run(self) -> Iterator[_Flake8Error]:
         mypy_cmdline = self.build_mypy_cmdline(self.filename, self.options.mypy_config)

--- a/flake8_mypy.py
+++ b/flake8_mypy.py
@@ -263,7 +263,7 @@ class MypyChecker:
             raise ValueError("unmatched line")
 
         lineno = int(m.group('lineno'))
-        column = int(m.group('column') or 0)
+        column = int(m.group('column') or 1) - 1
         message = m.group('message').strip()
         if m.group('class') == 'note':
             return T400(lineno, column, vars=(message,))


### PR DESCRIPTION
mypy changed the col base. We need to normalize this column to the base flake8 expects.
 
Tested with mypy-0.610

E.g. **before** the patch

```
> type plugin.py | C:\Dev\python36\Scripts\flake8.exe --format default -
C:\Users\c-flo\AppData\Local\Temp\flake8mypy_ynlp41vb\tmpmypy_06s72jce.py:17:1: error: Need type annotation for 'KNOWN_WINDOWS'
C:\Users\c-flo\AppData\Local\Temp\flake8mypy_ynlp41vb\tmpmypy_06s72jce.py:53:18: error: "str" has no attribute "window"

stdin:17:2: T484 Need type annotation for 'KNOWN_WINDOWS'
stdin:53:19: T484 "str" has no attribute "window"

```

First comes the raw stdout from mypy. You can see that mypy reports `17:1` but the flake8 output indicates an error at `17:2`

This patch of course reduces the failing Travis CI. And, unfortunately, this is again on top of my previous PR, but you can cherry-pick whatever you want. And the commits are tiny.