### PR TITLE
Compatibility with pythons that aren't 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - 3.6
     - 3.6-dev
     - 3.7-dev
+    - 3.7
 install:
   - python3 -m pip install -U git+git://github.com/python/mypy.git
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ install:
   - pip install -e .
 script: python setup.py test
 
-matrix:
-  allow_failures:
-    python: "3.7-dev"
+# use unsupported xenial
+dist: xenial
+sudo: required

--- a/flake8_mypy.py
+++ b/flake8_mypy.py
@@ -85,12 +85,12 @@ def calculate_mypypath() -> List[str]:
     if not typeshed_root:
         return []
 
-    stdlib_dirs = ('3.6', '3.5', '3.4', '3.3', '3.2', '3', '2and3')
+    stdlib_dirs = ('3.7', '3.6', '3.5', '3.4', '3.3', '3.2', '3', '2and3')
     stdlib_stubs = [
         typeshed_root / 'stdlib' / stdlib_dir
         for stdlib_dir in stdlib_dirs
     ]
-    third_party_dirs = ('3.6', '3', '2and3')
+    third_party_dirs = ('3.7', '3.6', '3', '2and3')
     third_party_stubs = [
         typeshed_root / 'third_party' / tp_dir
         for tp_dir in third_party_dirs
@@ -113,7 +113,6 @@ MYPY_ERROR_TEMPLATE = r"""
 $"""
 LOG = logging.getLogger('flake8.mypy')
 DEFAULT_ARGUMENTS = make_arguments(
-    python_version='3.6',
     platform='linux',
 
     # flake8-mypy expects the two following for sensible formatting

--- a/mypy_default.ini
+++ b/mypy_default.ini
@@ -2,7 +2,6 @@
 # Specify the target platform details in config, so your developers are
 # free to run mypy on Windows, Linux, or macOS and get consistent
 # results.
-python_version=3.7
 platform=linux
 
 # flake8-mypy expects the two following for sensible formatting

--- a/mypy_default.ini
+++ b/mypy_default.ini
@@ -2,7 +2,7 @@
 # Specify the target platform details in config, so your developers are
 # free to run mypy on Windows, Linux, or macOS and get consistent
 # results.
-python_version=3.6
+python_version=3.7
 platform=linux
 
 # flake8-mypy expects the two following for sensible formatting


### PR DESCRIPTION
Wild idea: try not hard-coding the version of python this depends on

When running flake8 as a pytest plugin it is not so straightforward to change command-line arguments to specify what version of python you are using, nor should you have to.